### PR TITLE
fix: Include Tcss files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,8 @@ setup(
     },
     description='Terminal UI for InvenTree',
     long_description=long_description,
-    long_description_content_type="text/markdown"
+    long_description_content_type="text/markdown",
+    package_data={
+        "inventree_tui": ["*.tcss"],
+    },
 )


### PR DESCRIPTION
This PR fixes a bug in the setup.py that left out the styling file that is needed by Texutalize to render the UI. All tcss files are included by default, this could be narrowed to only include the main tcss (there is currently only 1 tcss file in the repo)