### PR TITLE
feat: Test building package on master

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,18 @@
+name: Test Python Package build
+
+on:
+  push: 
+    branches:
+      - master
+  
+permissions:
+  contents: read
+
+jobs:
+  check-package:
+    name: Build & inspect our package.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hynek/build-and-inspect-python-package@v2


### PR DESCRIPTION
This PR adds a GitHub Action to test if the package is buildable on each commit to master.
This ensures the package can be build and exploses a reproducible "production" build on each commit to use for quick tests. Additionaly, this action als prints out the contents of the package - which is helpful in package debugging sessions. A sample run can be found in my fork ([here](https://github.com/matmair/inventree-tui/actions/runs/9422838346)). 